### PR TITLE
Implement ThemedReactContext as a decorator 

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -82,7 +82,7 @@ namespace ReactNative.Bridge
         /// Adds a lifecycle event listener to the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public virtual void AddLifecycleEventListener(ILifecycleEventListener listener)
+        public void AddLifecycleEventListener(ILifecycleEventListener listener)
         {
             _lock.EnterWriteLock();
             try
@@ -99,7 +99,7 @@ namespace ReactNative.Bridge
         /// Removes a lifecycle event listener from the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public virtual void RemoveLifecycleEventListener(ILifecycleEventListener listener)
+        public void RemoveLifecycleEventListener(ILifecycleEventListener listener)
         {
             _lock.EnterWriteLock();
             try

--- a/ReactWindows/ReactNative.Shared/UIManager/ThemedReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ThemedReactContext.cs
@@ -1,4 +1,5 @@
-﻿using ReactNative.Bridge;
+﻿using System;
+using ReactNative.Bridge;
 
 namespace ReactNative.UIManager
 {
@@ -6,7 +7,7 @@ namespace ReactNative.UIManager
     /// A wrapper <see cref="ReactContext"/> that delegates lifecycle events to
     /// the original instance of <see cref="ReactContext"/>.
     /// </summary>
-    public class ThemedReactContext : ReactContext
+    public class ThemedReactContext
     {
         private readonly ReactContext _reactContext;
 
@@ -16,15 +17,31 @@ namespace ReactNative.UIManager
         /// <param name="reactContext">The inner context.</param>
         public ThemedReactContext(ReactContext reactContext)
         {
-            InitializeWithInstance(reactContext.ReactInstance);
+            if (reactContext == null)
+            {
+                throw new ArgumentNullException(nameof(reactContext));   
+            }
+
             _reactContext = reactContext;
+        }
+
+        /// <summary>
+        /// Gets the instance of the <see cref="INativeModule"/> associated
+        /// with the <see cref="IReactInstance"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of native module.</typeparam>
+        /// <returns>The native module instance.</returns>
+        public T GetNativeModule<T>()
+            where T : INativeModule
+        {
+            return _reactContext.GetNativeModule<T>();
         }
 
         /// <summary>
         /// Adds a lifecycle event listener to the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public override void AddLifecycleEventListener(ILifecycleEventListener listener)
+        public void AddLifecycleEventListener(ILifecycleEventListener listener)
         {
             _reactContext.AddLifecycleEventListener(listener);
         }
@@ -33,7 +50,7 @@ namespace ReactNative.UIManager
         /// Removes a lifecycle event listener from the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public override void RemoveLifecycleEventListener(ILifecycleEventListener listener)
+        public void RemoveLifecycleEventListener(ILifecycleEventListener listener)
         {
             _reactContext.RemoveLifecycleEventListener(listener);
         }


### PR DESCRIPTION
The current implementation of the ThemedReactContext inherits from the ReactContext base class and takes a ReactContext instance in the constructor.  The ReactInstance from the ReactContext passed into the constructor is then bound to the ReactInstance field in the ThemedReactContext.  This pattern creates two instances of a ReactContext that share a single instance of a ReactInstance.  For the methods of ReactContext that act as pass-throughs to ReactInstance methods this works fine.  However, there are several methods and properties that do not involve the ReactInstance that may cause unexpected behavior.  The HandleException method in the current ThemedReactContext will not execute the NativeModuleCallExceptionHandler on the original ReactContext since the ThemedReactContext has its own instance.  Calling DisposeAsync on the ThemedReactContext will dispose of the shared ReactInstance.  Calling the  Add/Remove Listener, OnSuspend and OnResume methods on the ThemedReactContext will not affect the original ReactContext.   Those lifecycle methods will create a second lifecycle state that is disjoint from the master reactcontext...

It is assumed that the ThemedReactContext is being used as a conduit for passing additional information to view related methods while also providing access to the ReactContext for service location purposes... However, there may be a non-obvious intended pattern being used here that we do not understand completely.

This change purposes to change the implemetnation of the ThemedReactContext to be a "wrapper" or decorator around the ReactContext.  This would ensure that we only ever have one instance of the ReactContext and we provide the conduit for passing additional context to the view related methods...
